### PR TITLE
🦺 Disallow Absolute Paths in ChangesetEntry

### DIFF
--- a/src/main/java/io/codemodder/codetf/CodeTFChangesetEntry.java
+++ b/src/main/java/io/codemodder/codetf/CodeTFChangesetEntry.java
@@ -19,7 +19,7 @@ public final class CodeTFChangesetEntry {
       @JsonProperty("path") final String path,
       @JsonProperty("diff") final String diff,
       @JsonProperty("changes") final List<CodeTFChange> changes) {
-    this.path = CodeTFValidator.requireNonBlank(path);
+    this.path = CodeTFValidator.requireRelativePath(path);
     this.diff = CodeTFValidator.requireNonBlank(diff);
     this.changes = CodeTFValidator.toImmutableCopyOrEmptyOnNull(changes);
   }

--- a/src/main/java/io/codemodder/codetf/CodeTFValidator.java
+++ b/src/main/java/io/codemodder/codetf/CodeTFValidator.java
@@ -39,6 +39,18 @@ final class CodeTFValidator {
   }
 
   /**
+   * Returns the given {@link String} if it passes the two requirements -- it's not blank, and it is
+   * not an absolute path.
+   */
+  static String requireRelativePath(final String path) {
+    requireNonBlank(path);
+    if (path.startsWith("/")) {
+      throw new IllegalArgumentException("path must be relative");
+    }
+    return path;
+  }
+
+  /**
    * Given a {@link Map} that is possibly null, return an instance that represents an immutable copy
    * of it, or an empty map.
    */


### PR DESCRIPTION
Changeset's `path` property must be relative (to the workspace). See [CodeTF
spec](https://github.com/pixee/codemodder-specs/blob/main/codetf.json#L35). This change disallows invalid absolute paths in this property.