### PR TITLE
✅ Add a Regression Test

### DIFF
--- a/src/test/java/io/codemodder/codetf/CodeTFChangeTest.java
+++ b/src/test/java/io/codemodder/codetf/CodeTFChangeTest.java
@@ -2,6 +2,8 @@ package io.codemodder.codetf;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -48,5 +50,46 @@ final class CodeTFChangeTest {
         new CodeTFChange(1, null, null, CodeTFDiffSide.LEFT, null, null, List.of());
     assertEquals(change1, change2);
     assertEquals(change1.hashCode(), change2.hashCode());
+  }
+
+  /**
+   * Presently, there is a known issue where our Jackson databind annotations on {@link
+   * CodeTFChange} allow for this type to be deserialized with either property name {@code findings}
+   * or {@code fixedFindings}. The spec calls for {@code findings}. While we have not yet fixed this
+   * issue, this test demonstrates that the deserialization works as expected and serves as a
+   * regression test when we do fix the issue.
+   */
+  @Test
+  void parse_json() throws JsonProcessingException {
+    final CodeTFChange expected =
+        new CodeTFChange(
+            1,
+            null,
+            null,
+            CodeTFDiffSide.LEFT,
+            null,
+            null,
+            List.of(new FixedFinding("finding-id", new DetectorRule("java/xss", "XSS", null))));
+    String json =
+        """
+      {
+        "lineNumber": 1,
+        "properties": null,
+        "description": null,
+        "diffSide": "left",
+        "packageActions": null,
+        "parameters": null,
+        "findings": [{
+          "id": "finding-id",
+          "rule": {
+            "id": "java/xss",
+            "name": "XSS"
+          }
+        }]
+      }
+    """;
+    final var mapper = new ObjectMapper();
+    final var actual = mapper.readValue(json, CodeTFChange.class);
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
Added a test to help us identify strange behavior in our Jackson configuration. Checking the test in to serve as a regression test.